### PR TITLE
Move Discord section to dedicated tab

### DIFF
--- a/docs/discord/Gotchas/README.md
+++ b/docs/discord/Gotchas/README.md
@@ -1,0 +1,4 @@
+# Notes
+General notes related to Discord Bots that don't warrant a page of their own are outlined here
+
+- Sending messages in Text-in-Voice requires the `Connect` permission.

--- a/docs/vendor/discord/README.md
+++ b/docs/vendor/discord/README.md
@@ -1,1 +1,0 @@
-# Discord

--- a/docs/vendor/discord/bots-notes.md
+++ b/docs/vendor/discord/bots-notes.md
@@ -1,3 +1,0 @@
-# Notes about creating Discord bots
-
-Sending messages in Text-in-Voice requires the `Connect` permission.


### PR DESCRIPTION
Moves the "Discord" section that was previously under the "Vendors" tab to the dedicated "Discord" tab
General short notes about Discord bots that don't warrant a whole page of their own should go bullet-pointed into `discord/Gotchas/README.md`. The name of this folder is derived from common pitfalls and issues folks run into while creating Discord bots. Such pages should go under this folder.